### PR TITLE
Fixed compilation on GCC 8.2.0

### DIFF
--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -240,12 +240,14 @@ static unsigned int slot_offset(const struct target *target, slot_t slot)
 				case SLOT1: return 5;
 				case SLOT_LAST: return info->dramsize-1;
 			}
+			break;
 		case 64:
 			switch (slot) {
 				case SLOT0: return 4;
 				case SLOT1: return 6;
 				case SLOT_LAST: return info->dramsize-2;
 			}
+			break;
 	}
 	LOG_ERROR("slot_offset called with xlen=%d, slot=%d",
 			riscv_xlen(target), slot);


### PR DESCRIPTION
This fork fails to compile on GCC 8.2.0 on Ubuntu 18.10, due to protections against case fallthrough.
This patch simply adds break statements to one case statement in the RISC-V target to allow compilation to complete successfully.